### PR TITLE
fix(tui): stop the event handler on quit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
                 }
                 if !args.files.is_empty() {
                     tui.exit()?;
+                    state.running = false;
                     run(args)?;
                 }
             }


### PR DESCRIPTION
## Description of change

I realized we are not stopping the event handling loop when the restart command is send.

fixes #13

## How has this been tested? (if applicable)

Locally.
