### PR TITLE
feat(dynamic): make dynamic analysis optional for better platform support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,11 +7,90 @@ on:
 
 jobs:
   publish-github:
-    name: Publish on GitHub
-    runs-on: ubuntu-22.04
+    name: Publish for ${{ matrix.build.OS }} (${{ matrix.build.TARGET }})
+    runs-on: ${{ matrix.build.OS }}
     strategy:
+      fail-fast: false
       matrix:
-        TARGET: [x86_64-unknown-linux-gnu]
+        build:
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-unknown-linux-gnu,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-unknown-linux-musl,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: i686-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: i686-unknown-linux-musl,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-musl,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: armv5te-unknown-linux-gnueabi,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: armv7-unknown-linux-gnueabihf,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: arm-unknown-linux-gnueabi,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: arm-unknown-linux-gnueabihf,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: windows-2022,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-pc-windows-msvc,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: macos-14,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-apple-darwin,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: macos-14,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-apple-darwin,
+              ALL_FEATURES: false,
+            }
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -20,52 +99,76 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          targets: ${{ matrix.TARGET }}
+          toolchain: ${{ matrix.build.TOOLCHAIN }}
+          targets: ${{ matrix.build.TARGET }}
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.TARGET }}
+        shell: bash
+        run: |
+          if [ "${{ matrix.build.ALL_FEATURES }}" = true ]; then
+            cargo build --release --locked --target ${{ matrix.build.TARGET }}
+          else
+            cargo build --release --no-default-features --locked --target ${{ matrix.build.TARGET }}
+          fi
 
       - name: Prepare release assets
+        shell: bash
         run: |
           mkdir -p release
           cp {LICENSE-MIT,LICENSE-APACHE,README.md,CHANGELOG.md} release/
-          cp target/${{ matrix.TARGET }}/release/binsider release/ && strip -s release/binsider
+          if [ "${{ matrix.build.OS }}" = "windows-2022" ]; then
+            cp target/${{ matrix.build.TARGET }}/release/binsider.exe release/
+          else
+            cp target/${{ matrix.build.TARGET }}/release/binsider release/ && strip -s release/binsider
+          fi
           mv release/ binsider-${{env.RELEASE_VERSION}}/
 
       - name: Create release artifacts
+        shell: bash
         run: |
-          tar -czvf binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz \
-            binsider-${{ env.RELEASE_VERSION }}/
-          sha512sum binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz \
-            > binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz.sha512
+          if [ "${{ matrix.build.OS }}" = "windows-2022" ]; then
+            7z a -tzip "binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}.zip" \
+              binsider-${{ env.RELEASE_VERSION }}/
+          else
+            tar -czvf binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}.tar.gz \
+              binsider-${{ env.RELEASE_VERSION }}/
+            shasum -a 512 binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}.tar.gz \
+              > binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}.tar.gz.sha512
+          fi
 
       - name: Sign the release
+        if: matrix.build.OS != 'windows-2022'
         run: |
           echo "${{ secrets.GPG_RELEASE_KEY }}" | base64 --decode > private.key
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --pinentry-mode=loopback \
             --passphrase-fd 0 --import private.key
           echo "${{secrets.GPG_PASSPHRASE}}" | gpg --pinentry-mode=loopback \
             --passphrase-fd 0 --detach-sign \
-            binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz
+            binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}.tar.gz
 
       - name: Generate a changelog
         uses: orhun/git-cliff-action@v4
+        id: git-cliff
         with:
           args: --latest --github-repo ${{ github.repository }}
         env:
           OUTPUT: CHANGES.md
 
-      - name: Create release
-        run: |
-          gh release create "${{ github.ref_name }}" -F CHANGES.md
-          gh release upload "${{ github.ref_name }}" \
-            binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz \
-            binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz.sig \
-            binsider-${{ env.RELEASE_VERSION }}-${{ matrix.TARGET }}.tar.gz.sha512
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - name: Upload the binary releases
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: binsider-${{ env.RELEASE_VERSION }}-${{ matrix.build.TARGET }}*
+          file_glob: true
+          overwrite: true
+          tag: ${{ github.ref }}
+          release_name: "Release v${{ env.RELEASE_VERSION }}"
+          body: ${{ steps.git-cliff.outputs.content }}
+          repo_token: ${{ secrets.RELEASE_TOKEN }}
 
   publish-crates-io:
     name: Publish on crates.io

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,18 @@ jobs:
           - {
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-gnu,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: riscv64gc-unknown-linux-gnu,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
               TARGET: i686-unknown-linux-gnu,
               ALL_FEATURES: false,
             }
@@ -35,12 +47,6 @@ jobs:
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
               TARGET: i686-unknown-linux-musl,
-              ALL_FEATURES: false,
-            }
-          - {
-              OS: ubuntu-22.04,
-              TOOLCHAIN: stable,
-              TARGET: aarch64-unknown-linux-gnu,
               ALL_FEATURES: false,
             }
           - {

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,12 @@ jobs:
               ALL_FEATURES: false,
             }
           - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: powerpc64le-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
               OS: windows-2022,
               TOOLCHAIN: stable,
               TARGET: x86_64-pc-windows-msvc,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,79 @@ jobs:
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
               TARGET: x86_64-unknown-linux-gnu,
+              ALL_FEATURES: true,
             }
           - {
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
               TARGET: x86_64-unknown-linux-musl,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: i686-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: i686-unknown-linux-musl,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-musl,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: armv5te-unknown-linux-gnueabi,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: armv7-unknown-linux-gnueabihf,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: arm-unknown-linux-gnueabi,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: arm-unknown-linux-gnueabihf,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: windows-2022,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-pc-windows-msvc,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: macos-14,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-apple-darwin,
+              ALL_FEATURES: false,
+            }
+          - {
+              OS: macos-14,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-apple-darwin,
+              ALL_FEATURES: false,
             }
     steps:
       - name: Checkout the repository
@@ -51,7 +119,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build the project
-        run: cargo build --locked --verbose
+        shell: bash
+        run: |
+          if [ "${{ matrix.build.ALL_FEATURES }}" = true ]; then
+            cargo build --locked --verbose
+          else
+            cargo build --no-default-features --locked --verbose
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
               ALL_FEATURES: false,
             }
           - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: powerpc64le-unknown-linux-gnu,
+              ALL_FEATURES: false,
+            }
+          - {
               OS: windows-2022,
               TOOLCHAIN: stable,
               TARGET: x86_64-pc-windows-msvc,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
           - {
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-gnu,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: riscv64gc-unknown-linux-gnu,
+              ALL_FEATURES: true,
+            }
+          - {
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
               TARGET: i686-unknown-linux-gnu,
               ALL_FEATURES: false,
             }
@@ -40,12 +52,6 @@ jobs:
               OS: ubuntu-22.04,
               TOOLCHAIN: stable,
               TARGET: i686-unknown-linux-musl,
-              ALL_FEATURES: false,
-            }
-          - {
-              OS: ubuntu-22.04,
-              TOOLCHAIN: stable,
-              TARGET: aarch64-unknown-linux-gnu,
               ALL_FEATURES: false,
             }
           - {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "lurk-cli"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf13337addf721f044c89275e9afda5387a56282869fe859c4fccf31b353bce"
+checksum = "5cceb96fb968271defe0e262d52580b7de1318ef3f2dd21412fc9e854969dabd"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tui-input = "0.10.1"
 tui-popup = "0.5.0"
 unicode-width = "0.1.11"
 textwrap = "0.16.1"
-lurk-cli = { version = "0.3.6", optional = true }
+lurk-cli = { version = "0.3.7", optional = true }
 nix = { version = "0.29.0", features = ["ptrace", "signal"] }
 ansi-to-tui = "6.0.0"
 console = "0.15.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ include = [
   "CHANGELOG.md",
 ]
 
+[features]
+default = ["dynamic-analysis"]
+dynamic-analysis = ["lurk-cli"]
+
 [dependencies]
 ratatui = "0.28.1"
 clap = { version = "4.5.17", features = ["derive", "env", "wrap_help", "cargo"] }
@@ -30,7 +34,7 @@ tui-input = "0.10.1"
 tui-popup = "0.5.0"
 unicode-width = "0.1.11"
 textwrap = "0.16.1"
-lurk-cli = "0.3.6"
+lurk-cli = { version = "0.3.6", optional = true }
 nix = { version = "0.29.0", features = ["ptrace", "signal"] }
 ansi-to-tui = "6.0.0"
 console = "0.15.8"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,6 @@ use crate::{
     elf::Elf,
     error::{Error, Result},
     file::FileInfo,
-    tracer::TraceData,
     tui::event::Event,
 };
 use elf::{endian::AnyEndian, ElfBytes};
@@ -17,6 +16,15 @@ use std::{
     sync::mpsc,
     thread,
 };
+
+/// Tracer data.
+#[derive(Debug, Default)]
+pub struct TraceData {
+    /// System calls.
+    pub syscalls: Vec<u8>,
+    /// Summary.
+    pub summary: Vec<u8>,
+}
 
 /// Binary analyzer.
 pub struct Analyzer<'a> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,10 +4,15 @@ use sysinfo::{Gid, Groups, Uid, Users};
 use crate::error::Result;
 use std::{
     fs::{self, File, OpenOptions},
-    os::unix::fs::{MetadataExt, PermissionsExt},
     path::PathBuf,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::MetadataExt;
 
 /// General file information.
 #[derive(Debug)]
@@ -64,6 +69,7 @@ pub struct FileDateInfo {
 
 impl<'a> FileInfo<'a> {
     /// Constructs a new instance.
+    #[cfg(not(target_os = "windows"))]
     pub fn new(path: &'a str, bytes: &'a [u8]) -> Result<Self> {
         let metadata = fs::metadata(path)?;
         let mode = metadata.permissions().mode();
@@ -141,6 +147,11 @@ impl<'a> FileInfo<'a> {
                 }
             },
         })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new(path: &'a str, bytes: &'a [u8]) -> Result<Self> {
+        unimplemented!()
     }
 
     /// Opens the file (with R/W if possible) and returns it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod args;
 pub mod error;
 
 /// System call tracer.
+#[cfg(feature = "dynamic-analysis")]
 pub mod tracer;
 
 /// File information.
@@ -34,7 +35,6 @@ use prelude::*;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::{env, fs, io};
-use tracer::TraceData;
 use tui::{state::State, ui::Tab, Tui};
 
 /// Runs binsider.
@@ -101,11 +101,13 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
                     state.handle_tab()?;
                 }
             }
+            #[cfg(feature = "dynamic-analysis")]
             Event::Trace => {
                 state.system_calls_loaded = false;
                 tui.toggle_pause()?;
                 tracer::trace_syscalls(state.analyzer.file.path, tui.events.sender.clone());
             }
+            #[cfg(feature = "dynamic-analysis")]
             Event::TraceResult(syscalls) => {
                 state.analyzer.tracer = match syscalls {
                     Ok(v) => v,
@@ -119,6 +121,8 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
                 tui.toggle_pause()?;
                 state.handle_tab()?;
             }
+            #[cfg(not(feature = "dynamic-analysis"))]
+            Event::Trace | Event::TraceResult(_) => {}
             Event::Restart(path) => {
                 let mut args = args.clone();
                 match path {

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -10,17 +10,9 @@ use nix::sys::wait::{waitpid, WaitPidFlag};
 
 use crate::error::{Error, Result};
 use crate::tui::event::Event;
+use crate::TraceData;
 
 use nix::unistd::{fork, ForkResult};
-
-/// Tracer data.
-#[derive(Debug, Default)]
-pub struct TraceData {
-    /// System calls.
-    pub syscalls: Vec<u8>,
-    /// Summary.
-    pub summary: Vec<u8>,
-}
 
 /// Trace system calls and signals.
 pub fn trace_syscalls(command: &str, event_sender: mpsc::Sender<Event>) {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,4 +1,5 @@
-use crate::{error::Result, tracer::TraceData};
+use crate::error::Result;
+use crate::TraceData;
 use ratatui::crossterm::event::{self, Event as CrosstermEvent, KeyEvent, MouseEvent};
 use std::path::PathBuf;
 use std::sync::{

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -244,127 +244,134 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
         banner_area[1],
     );
 
-    let lines = vec![
-        Line::from(vec![
-            "Size".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state.analyzer.file.size.to_string().fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            " ".into(),
-            "Blocks".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .blocks
-                .to_string()
-                .fg(state.accent_color),
-            " ".into(),
-        ]),
-        Line::from(vec![
-            "Block Size".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .block_size
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Device".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state.analyzer.file.links.to_string().fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Inode".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state.analyzer.file.inode.to_string().fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Links".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state.analyzer.file.links.to_string().fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Access".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .access
-                .mode
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Uid".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .access
-                .uid
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Gid".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .access
-                .gid
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Access".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .date
-                .access
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Modify".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .date
-                .modify
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Change".cyan(),
-            Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .date
-                .change
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-        Line::from(vec![
-            "Birth".cyan(),
-            Span::raw(":  ").fg(Color::Rgb(100, 100, 100)),
-            state
-                .analyzer
-                .file
-                .date
-                .birth
-                .to_string()
-                .fg(state.accent_color),
-        ]),
-    ];
+    let lines = if cfg!(target_os = "windows") {
+        vec![
+            Line::from("This feature is not implemented!"),
+            Line::from("See <https://github.com/orhun/binsider/issues/35>"),
+        ]
+    } else {
+        vec![
+            Line::from(vec![
+                "Size".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state.analyzer.file.size.to_string().fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                " ".into(),
+                "Blocks".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .blocks
+                    .to_string()
+                    .fg(state.accent_color),
+                " ".into(),
+            ]),
+            Line::from(vec![
+                "Block Size".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .block_size
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Device".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state.analyzer.file.links.to_string().fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Inode".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state.analyzer.file.inode.to_string().fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Links".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state.analyzer.file.links.to_string().fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Access".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .access
+                    .mode
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Uid".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .access
+                    .uid
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Gid".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .access
+                    .gid
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Access".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .date
+                    .access
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Modify".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .date
+                    .modify
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Change".cyan(),
+                Span::raw(": ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .date
+                    .change
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+            Line::from(vec![
+                "Birth".cyan(),
+                Span::raw(":  ").fg(Color::Rgb(100, 100, 100)),
+                state
+                    .analyzer
+                    .file
+                    .date
+                    .birth
+                    .to_string()
+                    .fg(state.accent_color),
+            ]),
+        ]
+    };
 
     let info_width = lines.iter().map(|v| v.width()).max().unwrap_or_default() as u16 + 2;
     let rect = area[2].inner(Margin {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -909,14 +909,30 @@ fn render_details(state: &mut State<'_>, area: Rect, frame: &mut Frame<'_>) {
 /// Renders the dynamic analysis tab.
 pub fn render_dynamic_analysis(state: &mut State, frame: &mut Frame, rect: Rect) {
     if !state.system_calls_loaded {
-        frame.render_widget(
-            Paragraph::new(vec![Line::from(vec![
+        let lines = if cfg!(feature = "dynamic-analysis") {
+            vec![Line::from(vec![
                 "Press ".into(),
                 "Enter".yellow(),
                 " to run the executable.".into(),
-            ])])
-            .block(Block::bordered())
-            .alignment(Alignment::Center),
+            ])]
+        } else {
+            vec![
+                Line::from(vec![
+                    "You need to enable the ".into(),
+                    "\"dynamic-analysis\"".yellow(),
+                    " feature at build time to use this functionality!".into(),
+                ]),
+                Line::from(vec![
+                    "(This is currently only supported on ".into(),
+                    "Linux".cyan(),
+                    ")".into(),
+                ]),
+            ]
+        };
+        frame.render_widget(
+            Paragraph::new(Text::from(lines))
+                .block(Block::bordered())
+                .alignment(Alignment::Center),
             rect,
         );
     } else {

--- a/website/src/content/docs/installation/binary-releases.md
+++ b/website/src/content/docs/installation/binary-releases.md
@@ -8,16 +8,17 @@ See the available binaries for different operating systems/architectures from th
 
 :::note
 
-- Only the `x86_64-unknown-linux-gnu` target is provided for now.
-- Release tarballs are signed with the following PGP key: [0C9E792408F77819866E47FA85EF5848473D7F88](https://keyserver.ubuntu.com/pks/lookup?search=0x85EF5848473D7F88&op=vindex)
+- Release tarballs for Linux/macOS are signed with the following PGP key: [0C9E792408F77819866E47FA85EF5848473D7F88](https://keyserver.ubuntu.com/pks/lookup?search=0x85EF5848473D7F88&op=vindex)
+- If you are using Windows, you can simply download the zip file from the [releases page](https://github.com/orhun/binsider/releases).
 
 :::
 
-1. Download the binary from [releases](https://github.com/orhun/binsider/releases)
+1. Download the binary from [releases](https://github.com/orhun/binsider/releases):
 
 ```bash
 VERSION="0.1.0"
-wget "https://github.com/orhun/binsider/releases/download/v${VERSION}/binsider-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+TARGET="x86_64-unknown-linux-gnu.tar.gz"
+wget "https://github.com/orhun/binsider/releases/download/v${VERSION}/binsider-${VERSION}-${TARGET}.tar.gz"
 ```
 
 2. Extract the files:

--- a/website/src/content/docs/installation/build-from-source.md
+++ b/website/src/content/docs/installation/build-from-source.md
@@ -25,3 +25,13 @@ CARGO_TARGET_DIR=target cargo build --release
 ```
 
 Binary will be located at `target/release/binsider`.
+
+:::tip
+
+If the build fails you can try disabling some of the [feature flags](/installation/crates-io/#features), for example:
+
+```bash
+CARGO_TARGET_DIR=target cargo build --release --no-default-features
+```
+
+:::

--- a/website/src/content/docs/installation/crates-io.md
+++ b/website/src/content/docs/installation/crates-io.md
@@ -21,3 +21,15 @@ cargo install --git https://github.com/orhun/binsider
 The minimum supported Rust version (MSRV) is `1.74.1`.
 
 :::
+
+## Features
+
+`binsider` supports the following feature flags which can be enabled or disabled during installation:
+
+- `dynamic-analysis`: Enables the [dynamic analysis](/usage/dynamic-analysis) feature. (default: enabled)
+
+e.g. To install `binsider` with the `dynamic-analysis` feature disabled:
+
+```bash
+cargo install binsider --no-default-features
+```


### PR DESCRIPTION
## Description of change

This PR makes it possible to build `binsider` without dynamic analysis feature thus without `lurk-cli` dependency.

Simply run:

```bash
cargo build --no-default-features
```

Potential workaround for #10, #12, #15 and other similar issues.

## How has this been tested? (if applicable)

Locally.
