### PR TITLE
fix(dynamic): sort the shared library list

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -351,18 +351,9 @@ impl<'a> State<'a> {
                 self.list = SelectableList::with_items(
                     self.analyzer
                         .dependencies
-                        .libraries
                         .clone()
                         .into_iter()
-                        .map(|(name, lib)| {
-                            vec![
-                                name.to_string(),
-                                lib.realpath
-                                    .unwrap_or(lib.path)
-                                    .to_string_lossy()
-                                    .to_string(),
-                            ]
-                        })
+                        .map(|(name, lib)| vec![name, lib])
                         .collect(),
                 );
             }


### PR DESCRIPTION
## Description of change

Now we sort the list of shared libraries.

If the library starts with `lib` it takes precedence.

## How has this been tested? (if applicable)

Locally.
