### PR TITLE
feat(cli): add `--tab` argument

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::prelude::Tab;
+use crate::tui::ui::Tab;
 
 /// Argument parser powered by [`clap`].
 #[derive(Clone, Debug, Default, Parser)]
@@ -28,7 +28,7 @@ pub struct Args {
     #[arg(env, short = 'n', long = "min-len", default_value = "15")]
     pub min_strings_len: usize,
 
-    /// The tab binsider will start at
+    /// The initial application tab to open.
     #[arg(env, short = 't', long = "tab", default_value = "general")]
     pub tab: Tab,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use std::path::PathBuf;
 
+use crate::prelude::Tab;
+
 /// Argument parser powered by [`clap`].
 #[derive(Clone, Debug, Default, Parser)]
 #[clap(
@@ -25,6 +27,10 @@ pub struct Args {
     /// Minimum length of strings.
     #[arg(env, short = 'n', long = "min-len", default_value = "15")]
     pub min_strings_len: usize,
+
+    /// The tab binsider will start at
+    #[arg(env, short = 't', long = "tab", default_value = "general")]
+    pub tab: Tab,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
     // Create an application.
     let mut state = State::new(analyzer)?;
 
-    // Change tab depending on cli arguments 
+    // Change tab depending on cli arguments.
     state.set_tab(args.tab);
 
     // Initialize the terminal user interface.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
     // Create an application.
     let mut state = State::new(analyzer)?;
 
+    // Change tab depending on cli arguments 
+    state.set_tab(args.tab);
+
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -484,4 +484,9 @@ impl<'a> State<'a> {
             ],
         }
     }
+
+    /// Changes the tab
+    pub fn set_tab(&mut self, tab: Tab) {
+        self.tab = tab;
+    }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -35,7 +35,7 @@ pub const ELF_INFO_TABS: &[Info] = &[
 ];
 
 /// Application tab.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
 pub enum Tab {
     /// General information.
     General = 0,


### PR DESCRIPTION
<!--- Thank you for contributing to binsider! -->

## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This feature lets user launch binsider from a different tab other than general
closes #6 

## How has this been tested? (if applicable)

running `binsider` should start at general tab, the default value 
if you run 
```shell
binsider --tab hexdump
```
binsider should be running at hexdump tab

also if you mistype you get this message 
```shell
❯ binsider --tab hex
error: invalid value 'hex' for '--tab <TAB>'
  [possible values: general, static-analysis, dynamic-analysis, strings, hexdump]

  tip: a similar value exists: 'hexdump'

For more information, try '--help'.
```

<!-- Please describe any tests that you ran to verify your changes. -->
