### PR TITLE
fix(tui)!: query the terminal background once

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
         file_data.as_slice(),
     )?;
     let analyzer = Analyzer::new(file_info, 15, vec![])?;
-    let mut state = State::new(analyzer)?;
+    let mut state = State::new(analyzer, None)?;
     let (sender, receiver) = mpsc::channel();
     state.analyzer.extract_strings(sender.clone());
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use ratatui::style::Color;
 use std::path::PathBuf;
 
 use crate::tui::ui::Tab;
@@ -31,6 +32,10 @@ pub struct Args {
     /// The initial application tab to open.
     #[arg(env, short = 't', long = "tab", default_value = "general")]
     pub tab: Tab,
+
+    /// Accent color of the application.
+    #[arg(env, long, value_name = "COLOR")]
+    pub accent_color: Option<Color>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn run(mut args: Args) -> Result<()> {
 /// Starts the terminal user interface.
 pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
     // Create an application.
-    let mut state = State::new(analyzer)?;
+    let mut state = State::new(analyzer, args.accent_color)?;
 
     // Change tab depending on cli arguments.
     state.set_tab(args.tab);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,24 @@
 use binsider::args::Args;
 use binsider::error::Result;
 use clap::Parser;
+use ratatui::style::Color;
 use std::process;
+use std::time::Duration;
+use termbg::Theme;
 
 fn main() -> Result<()> {
-    let args = Args::parse();
+    let mut args = Args::parse();
+    if args.accent_color.is_none() {
+        args.accent_color = termbg::theme(Duration::from_millis(10))
+            .map(|theme| {
+                if theme == Theme::Dark {
+                    Color::White
+                } else {
+                    Color::Black
+                }
+            })
+            .ok();
+    }
     match binsider::run(args) {
         Ok(_) => process::exit(0),
         Err(e) => {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::sync::mpsc;
-use std::time::Duration;
 
 use crate::error::{Error, Result};
 use crate::prelude::Analyzer;
@@ -12,7 +11,6 @@ use crate::tui::widgets::logo::Logo;
 use ansi_to_tui::IntoText;
 use heh::windows::Window;
 use ratatui::style::Color;
-use termbg::Theme;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
@@ -59,7 +57,7 @@ pub struct State<'a> {
 
 impl<'a> State<'a> {
     /// Constructs a new instance of [`State`].
-    pub fn new(analyzer: Analyzer<'a>) -> Result<Self> {
+    pub fn new(analyzer: Analyzer<'a>, accent_color: Option<Color>) -> Result<Self> {
         let mut state = Self {
             running: true,
             tab: Tab::default(),
@@ -77,15 +75,7 @@ impl<'a> State<'a> {
             general_scroll_index: 0,
             notes_scroll_index: 0,
             headers_scroll_index: 0,
-            accent_color: termbg::theme(Duration::from_millis(10))
-                .map(|theme| {
-                    if theme == Theme::Dark {
-                        Color::White
-                    } else {
-                        Color::Black
-                    }
-                })
-                .unwrap_or(Color::White),
+            accent_color: accent_color.unwrap_or(Color::White),
             logo: Logo::default(),
         };
         state.handle_tab()?;

--- a/website/src/content/docs/extras/library.md
+++ b/website/src/content/docs/extras/library.md
@@ -21,7 +21,7 @@ Then you can create a `Analyzer` struct and `State` for managing the TUI state:
 use binsider::prelude::*;
 
 let analyzer = Analyzer::new(file_info, 15, vec![])?;
-let mut state = State::new(analyzer)?;
+let mut state = State::new(analyzer, None)?;
 ```
 
 To render a frame:


### PR DESCRIPTION
## Description of change

fixes #59

Also adds a new CLI argument for overriding the accent color.

## How has this been tested? (if applicable)

Locally.
