### PR TITLE
feat(static): add human readable option for program headers

### DIFF
--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -1,5 +1,7 @@
 use crate::elf::Property;
 use elf::parse::ParsingTable;
+extern crate bytesize;
+use bytesize::ByteSize;
 use elf::section::SectionHeader;
 use elf::segment::ProgramHeader;
 use elf::string_table::StringTable;
@@ -111,33 +113,64 @@ impl<'a> Property<'a> for FileHeaders {
 pub struct ProgramHeaders {
     /// Inner type.
     inner: Vec<ProgramHeader>,
+    /// Human readable format
+    human_readable: bool,
+}
+impl ProgramHeaders {
+    /// Toggle's the value for human_readable format
+    pub fn set_value(&mut self) {
+        self.human_readable = !self.human_readable;
+    }
 }
 
 impl From<Vec<ProgramHeader>> for ProgramHeaders {
     fn from(inner: Vec<ProgramHeader>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            human_readable: false,
+        }
     }
 }
 
 impl<'a> Property<'a> for ProgramHeaders {
     fn items(&self) -> Vec<Vec<String>> {
-        self.inner
-            .iter()
-            .map(|item| {
-                vec![
-                    elf::to_str::p_type_to_string(item.p_type)
-                        .trim_start_matches("PT_")
-                        .to_string(),
-                    format!("{:#x}", item.p_offset),
-                    format!("{:#x}", item.p_vaddr),
-                    format!("{:#x}", item.p_paddr),
-                    format!("{:#x}", item.p_filesz),
-                    format!("{:#x}", item.p_memsz),
-                    elf::to_str::p_flags_to_string(item.p_flags),
-                    format!("{:#x}", item.p_align),
-                ]
-            })
-            .collect()
+        if !self.human_readable {
+            self.inner
+                .iter()
+                .map(|item| {
+                    vec![
+                        elf::to_str::p_type_to_string(item.p_type)
+                            .trim_start_matches("PT_")
+                            .to_string(),
+                        format!("{:#x}", item.p_offset),
+                        format!("{:#x}", item.p_vaddr),
+                        format!("{:#x}", item.p_paddr),
+                        format!("{:#x}", item.p_filesz),
+                        format!("{:#x}", item.p_memsz),
+                        elf::to_str::p_flags_to_string(item.p_flags),
+                        format!("{:#x}", item.p_align),
+                    ]
+                })
+                .collect()
+        } else {
+            self.inner
+                .iter()
+                .map(|item| {
+                    vec![
+                        elf::to_str::p_type_to_string(item.p_type)
+                            .trim_start_matches("PT_")
+                            .to_string(),
+                        format!("{:#x}", item.p_offset),
+                        format!("{:#x}", item.p_vaddr),
+                        format!("{:#x}", item.p_paddr),
+                        format!("{}", ByteSize(item.p_filesz)),
+                        format!("{}", ByteSize(item.p_memsz)),
+                        elf::to_str::p_flags_to_string(item.p_flags),
+                        format!("{:#x}", item.p_align),
+                    ]
+                })
+                .collect()
+        }
     }
 }
 

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -115,9 +115,10 @@ pub struct ProgramHeaders {
     /// Human readable format
     human_readable: bool,
 }
+
 impl ProgramHeaders {
-    /// Toggle's the value for human_readable format
-    pub fn set_value(&mut self) {
+    /// Toggles the value for human readable format.
+    pub fn toggle_readability(&mut self) {
         self.human_readable = !self.human_readable;
     }
 }
@@ -126,7 +127,7 @@ impl From<Vec<ProgramHeader>> for ProgramHeaders {
     fn from(inner: Vec<ProgramHeader>) -> Self {
         Self {
             inner,
-            human_readable: false,
+            human_readable: true,
         }
     }
 }

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -1,7 +1,6 @@
 use crate::elf::Property;
-use elf::parse::ParsingTable;
-extern crate bytesize;
 use bytesize::ByteSize;
+use elf::parse::ParsingTable;
 use elf::section::SectionHeader;
 use elf::segment::ProgramHeader;
 use elf::string_table::StringTable;
@@ -134,43 +133,31 @@ impl From<Vec<ProgramHeader>> for ProgramHeaders {
 
 impl<'a> Property<'a> for ProgramHeaders {
     fn items(&self) -> Vec<Vec<String>> {
-        if !self.human_readable {
-            self.inner
-                .iter()
-                .map(|item| {
-                    vec![
-                        elf::to_str::p_type_to_string(item.p_type)
-                            .trim_start_matches("PT_")
-                            .to_string(),
-                        format!("{:#x}", item.p_offset),
-                        format!("{:#x}", item.p_vaddr),
-                        format!("{:#x}", item.p_paddr),
-                        format!("{:#x}", item.p_filesz),
-                        format!("{:#x}", item.p_memsz),
-                        elf::to_str::p_flags_to_string(item.p_flags),
-                        format!("{:#x}", item.p_align),
-                    ]
-                })
-                .collect()
-        } else {
-            self.inner
-                .iter()
-                .map(|item| {
-                    vec![
-                        elf::to_str::p_type_to_string(item.p_type)
-                            .trim_start_matches("PT_")
-                            .to_string(),
-                        format!("{:#x}", item.p_offset),
-                        format!("{:#x}", item.p_vaddr),
-                        format!("{:#x}", item.p_paddr),
-                        format!("{}", ByteSize(item.p_filesz)),
-                        format!("{}", ByteSize(item.p_memsz)),
-                        elf::to_str::p_flags_to_string(item.p_flags),
-                        format!("{:#x}", item.p_align),
-                    ]
-                })
-                .collect()
-        }
+        self.inner
+            .iter()
+            .map(|item| {
+                vec![
+                    elf::to_str::p_type_to_string(item.p_type)
+                        .trim_start_matches("PT_")
+                        .to_string(),
+                    format!("{:#x}", item.p_offset),
+                    format!("{:#x}", item.p_vaddr),
+                    format!("{:#x}", item.p_paddr),
+                    if self.human_readable {
+                        format!("{}", ByteSize(item.p_filesz))
+                    } else {
+                        format!("{:#x}", item.p_filesz)
+                    },
+                    if self.human_readable {
+                        format!("{}", ByteSize(item.p_memsz))
+                    } else {
+                        format!("{:#x}", item.p_memsz)
+                    },
+                    elf::to_str::p_flags_to_string(item.p_flags),
+                    format!("{:#x}", item.p_align),
+                ]
+            })
+            .collect()
     }
 }
 

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -138,7 +138,7 @@ impl Elf {
         }
     }
     /// sets program_headers as human_readable
-    pub fn set_human_readable(&mut self) {
+    pub fn toggle_human_readable(&mut self) {
         self.program_headers.set_value();
     }
 }

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -137,4 +137,8 @@ impl Elf {
             Info::Notes => todo!(),
         }
     }
+    /// sets program_headers as human_readable
+    pub fn set_human_readable(&mut self) {
+        self.program_headers.set_value();
+    }
 }

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -137,8 +137,4 @@ impl Elf {
             Info::Notes => todo!(),
         }
     }
-    /// sets program_headers as human_readable
-    pub fn toggle_human_readable(&mut self) {
-        self.program_headers.set_value();
-    }
 }

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -45,6 +45,8 @@ pub enum Command {
     Exit,
     /// Do nothing.
     Nothing,
+    /// Change data to human readable format
+    HumanReadable,
 }
 
 impl From<KeyEvent> for Command {
@@ -98,6 +100,7 @@ impl From<KeyEvent> for Command {
             KeyCode::Enter => Self::ShowDetails,
             KeyCode::Char('o') => Self::OpenRepo,
             KeyCode::Char('r') => Self::TraceCalls,
+            KeyCode::Char('s') => Self::HumanReadable,
             _ => Self::Nothing,
         }
     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -457,9 +457,9 @@ impl<'a> State<'a> {
             Tab::StaticAnalysis => vec![
                 ("Enter", "Details"),
                 ("/", "Search"),
-                ("s", "Human Readable"),
                 ("h/j/k/l", "Scroll"),
                 ("n/p", "Toggle"),
+                ("s", "Readability"),
                 ("Tab", "Next"),
                 ("q", "Quit"),
             ],

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -355,7 +355,7 @@ impl<'a> State<'a> {
             }
             Command::HumanReadable => {
                 if self.tab == Tab::StaticAnalysis {
-                    self.analyzer.elf.toggle_human_readable();
+                    self.analyzer.elf.program_headers.toggle_readability();
                     self.handle_tab()?;
                 }
             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -353,6 +353,26 @@ impl<'a> State<'a> {
                     self.running = false;
                 }
             }
+            Command::HumanReadable => {
+                if self.tab == Tab::StaticAnalysis {
+                    self.analyzer.elf.set_human_readable();
+                    self.list = SelectableList::with_items(
+                        self.analyzer
+                            .elf
+                            .info(&ELF_INFO_TABS[self.info_index])
+                            .items()
+                            .into_iter()
+                            .filter(|items| {
+                                self.input.value().is_empty()
+                                    || items.iter().any(|item| {
+                                        item.to_lowercase()
+                                            .contains(&self.input.value().to_lowercase())
+                                    })
+                            })
+                            .collect(),
+                    );
+                }
+            }
             Command::Nothing => {}
         }
         Ok(())
@@ -451,6 +471,7 @@ impl<'a> State<'a> {
             Tab::StaticAnalysis => vec![
                 ("Enter", "Details"),
                 ("/", "Search"),
+                ("s", "Human Readable"),
                 ("h/j/k/l", "Scroll"),
                 ("n/p", "Toggle"),
                 ("Tab", "Next"),

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -355,22 +355,8 @@ impl<'a> State<'a> {
             }
             Command::HumanReadable => {
                 if self.tab == Tab::StaticAnalysis {
-                    self.analyzer.elf.set_human_readable();
-                    self.list = SelectableList::with_items(
-                        self.analyzer
-                            .elf
-                            .info(&ELF_INFO_TABS[self.info_index])
-                            .items()
-                            .into_iter()
-                            .filter(|items| {
-                                self.input.value().is_empty()
-                                    || items.iter().any(|item| {
-                                        item.to_lowercase()
-                                            .contains(&self.input.value().to_lowercase())
-                                    })
-                            })
-                            .collect(),
-                    );
+                    self.analyzer.elf.toggle_human_readable();
+                    self.handle_tab()?;
                 }
             }
             Command::Nothing => {}


### PR DESCRIPTION

## Description of change
Added KeyCommand HumanReadable that toggles the format for FileSiz and MemSiz in Tab::StaticAnalysis => Program Headers. Keybind is 's'

Closes Issue #47


## How has this been tested? (if applicable)
Verified the program to correctly toggle human readable on and off only on tab StaticAnalysis.
