### PR TITLE
fix(dynamic): only allow tracing calls while on the dynamic analysis tab

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -203,9 +203,11 @@ impl<'a> State<'a> {
                 }
             }
             Command::TraceCalls => {
-                event_sender
-                    .send(Event::Trace)
-                    .expect("failed to send trace event");
+                if self.tab == Tab::DynamicAnalysis {
+                    event_sender
+                        .send(Event::Trace)
+                        .expect("failed to send trace event");
+                }
             }
             Command::Next(scroll_type, amount) => match scroll_type {
                 ScrollType::Tab => {


### PR DESCRIPTION
## Description of change

See https://github.com/orhun/binsider/pull/77#discussion_r1796114961

## How has this been tested? (if applicable)

Locally.
