### PR TITLE
chore(github): create PRs for nix flake updates automatically

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -1,0 +1,26 @@
+name: Update Nix flake
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+jobs:
+  update-flake:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          commit-msg: "chore(deps): bump flake.lock"
+          pr-title: "chore(deps): bump flake.lock"
+          pr-labels: |
+            dependencies
+            github_actions

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,10 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?nixpkgs-unstable";
-    naersk.url = "github:nix-community/naersk";
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
<!--- Thank you for contributing to binsider! -->

## Description of change
Automatically creates PR with `flake.lock` update, which is file with Nix dependencies
It doesn't run it on PRs not to create PRs from PRs
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

## How has this been tested? (if applicable)
Here is action run https://github.com/thingsbych/binsider/actions/runs/11388924732/job/31687028064
And PR that it created https://github.com/thingsbych/binsider/pull/3
<!-- Please describe any tests that you ran to verify your changes. -->
