### PR TITLE
WIP: Make visible cursor in search field move with index (fix #92)

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -931,13 +931,10 @@ pub fn render_strings(state: &mut State, frame: &mut Frame, rect: Rect) {
 
 /// Renders the cursor.
 fn render_cursor(state: &mut State<'_>, area: Rect, frame: &mut Frame<'_>) {
+    let scroll = state.input.visual_scroll(area.width as usize);
     if state.input_mode {
         let (x, y) = (
-            area.x
-                + Input::default()
-                    .with_value(format!("search: {}", state.input.value()))
-                    .visual_cursor() as u16
-                + 2,
+            area.x + ((state.input.visual_cursor()).max(scroll) - scroll) as u16 + 10, // +10: simply to jump over the box chars and "search: " string
             area.bottom().saturating_sub(1),
         );
         frame.render_widget(


### PR DESCRIPTION
## Description of change

I made the visible cursor move with the index of the current search pattern using the `visual_cursor()` and `visual_scroll` method of the `tui_input` crate. It works now, but the cursor still hides the underlaying character. Maybe the order of the inner `render` functions for each tab has to be changed (at least that worked in my own tui app). But your rendering code is quite complex and I hadn't the time to skim through all details.

Though, I still hope this WIP PR helps with the issue.
