### PR TITLE
fix(ui): don't exit when typing 'q' in hexdump search and jump

### DIFF
--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -160,14 +160,14 @@ pub enum HexdumpCommand {
     /// Cancel hexdump and move to the previous tab.
     CancelPrevious,
     /// Exit application.
-    Exit,
+    Exit(Event),
 }
 
 impl HexdumpCommand {
     /// Parses the event.
     pub fn parse(key_event: KeyEvent, is_read_only: bool) -> Self {
         match key_event.code {
-            KeyCode::Char('q') => Self::Exit,
+            KeyCode::Char('q') => Self::Exit(Event::Key(key_event)),
             KeyCode::Tab => Self::CancelNext,
             KeyCode::BackTab => Self::CancelPrevious,
             KeyCode::Char('s') => {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -176,8 +176,21 @@ impl<'a> State<'a> {
                         .into();
                     self.handle_tab()?;
                 }
-                HexdumpCommand::Exit => {
-                    self.running = false;
+                HexdumpCommand::Exit(event) => {
+                    if self.analyzer.heh.key_handler.is_focusing(Window::Search)
+                        || self
+                            .analyzer
+                            .heh
+                            .key_handler
+                            .is_focusing(Window::JumpToByte)
+                    {
+                        self.analyzer
+                            .heh
+                            .handle_input(&event)
+                            .map_err(|e| Error::HexdumpError(e.to_string()))?;
+                    } else {
+                        self.running = false;
+                    }
                 }
             },
             Command::ShowDetails => {


### PR DESCRIPTION
<!--- Thank you for contributing to binsider! -->

## Description of change

The effect of the change was manually tested.
