### PR TITLE
feat: add search filtering to shared libraries tab

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -377,11 +377,17 @@ impl<'a> State<'a> {
         self.show_heh = false;
         match self.tab {
             Tab::General => {
+                let search_query = self.input.value().to_lowercase();
                 self.list = SelectableList::with_items(
                     self.analyzer
                         .dependencies
                         .clone()
                         .into_iter()
+                        .filter(|(name, lib)| {
+                            search_query.is_empty()
+                                || name.to_lowercase().contains(&search_query)
+                                || lib.to_lowercase().contains(&search_query)
+                        })
                         .map(|(name, lib)| vec![name, lib])
                         .collect(),
                 );
@@ -455,6 +461,7 @@ impl<'a> State<'a> {
                 vec![
                     ("o", "Open docs"),
                     ("⏎ ", "Analyze lib"),
+                    ("/", "Search"),
                     ("h/j/k/l", "Scroll"),
                     ("Tab", "Next"),
                     ("⇧+Tab", "Previous"),

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -381,14 +381,13 @@ impl<'a> State<'a> {
                 self.list = SelectableList::with_items(
                     self.analyzer
                         .dependencies
-                        .clone()
-                        .into_iter()
+                        .iter()
                         .filter(|(name, lib)| {
                             search_query.is_empty()
                                 || name.to_lowercase().contains(&search_query)
                                 || lib.to_lowercase().contains(&search_query)
                         })
-                        .map(|(name, lib)| vec![name, lib])
+                        .map(|(name, lib)| vec![name.clone(), lib.clone()])
                         .collect(),
                 );
             }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -497,6 +497,22 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
         .map(Row::new)
         .collect::<Vec<Row>>();
 
+    let input_line: Line = if !state.input.value().is_empty() || state.input_mode {
+        Line::from(vec![
+            "|".fg(Color::Rgb(100, 100, 100)),
+            "search: ".yellow(),
+            state
+                .input
+                .value()
+                .to_string()
+                .fg(state.accent_color),
+            if state.input_mode { " " } else { "" }.into(),
+            "|".fg(Color::Rgb(100, 100, 100)),
+        ])
+    } else {
+        Line::default()
+    };
+
     frame.render_stateful_widget(
         Table::new(
             items.clone(),
@@ -537,12 +553,14 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
                         Line::default()
                     }
                     .right_aligned(),
-                ),
+                )
+                .title_bottom(input_line),
         )
         .row_highlight_style(Style::default().fg(Color::Green)),
         table_area,
         &mut state.list.state,
     );
+    render_cursor(state, table_area, frame);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("↑"))

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -501,11 +501,7 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
         Line::from(vec![
             "|".fg(Color::Rgb(100, 100, 100)),
             "search: ".yellow(),
-            state
-                .input
-                .value()
-                .to_string()
-                .fg(state.accent_color),
+            state.input.value().to_string().fg(state.accent_color),
             if state.input_mode { " " } else { "" }.into(),
             "|".fg(Color::Rgb(100, 100, 100)),
         ])


### PR DESCRIPTION
Adds `/` search functionality to the General tab (shared libraries).

- Filters by library name or path (case-insensitive)
- Empty query shows all entries

Closes #45