### PR TITLE
fix(deps): bump lurk-cli to fix riscv64 build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "lurk-cli"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1022a90d065e8d770674b51ea42f7f4ed3a7a82f1f3d932b1ad63764fa958c"
+checksum = "d4b7e2dacc544da6208f262c3cf30640a1d67cde6c5e15374d4678ffd0f0d872"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "syscalls"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90db46b5b4962319605d435986c775ea45a0ad2561c09e1d5372b89afeb49cf4"
+checksum = "81c645a4de0d803ced6ef0388a2646aa1ef8467173b5d59a2c33c88de4ab76e7"
 dependencies = [
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tui-input = "0.15.0"
 tui-popup = "0.7.2"
 unicode-width = "0.2.2"
 textwrap = "0.16.2"
-lurk-cli = { version = "0.3.12", optional = true }
+lurk-cli = { version = "0.3.14", optional = true }
 serde = "1.0.228" 
 serde_derive = "1.0.228"
 nix = { version = "0.30.1", features = ["ptrace", "signal"] }


### PR DESCRIPTION
<!--- Thank you for contributing to binsider! -->

## Description of change

This PR fixes a build error on linux riscv64 as shown in https://archriscv.felixc.at/.status/log.htm?url=logs/binsider/binsider-0.3.2-2.log.

This PR bumps lurk-cli to the latest verison that contains the fix(https://github.com/JakWai01/lurk/pull/79) for the build error.
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

## How has this been tested? (if applicable)

Build this package on riscv64 linux.
<!-- Please describe any tests that you ran to verify your changes. -->
