### PR TITLE
feat(tui): add command prompt mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,11 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
             Event::Key(key_event) => {
                 let command = if state.input_mode {
                     Command::Input(InputCommand::parse(key_event, &state.input))
+                } else if state.command_mode {
+                    Command::CommandPrompt(CommandPromptCommand::parse(
+                        key_event,
+                        &state.command_input,
+                    ))
                 } else if state.show_heh {
                     Command::Hexdump(HexdumpCommand::parse(
                         key_event,

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -47,6 +47,27 @@ pub enum Command {
     Nothing,
     /// Change data to human readable format
     HumanReadable,
+    /// Command prompt command.
+    CommandPrompt(CommandPromptCommand),
+}
+
+impl Command {
+    /// Parses a command typed in the command prompt (e.g. `:quit`).
+    ///
+    /// Returns [`None`] if the input does not match any known command.
+    pub fn parse_prompt(input: &str) -> Option<Self> {
+        match input.trim() {
+            "q" | "quit" | "exit" => Some(Self::Exit),
+            "top" => Some(Self::Top),
+            "bottom" => Some(Self::Bottom),
+            "next" => Some(Self::Next(ScrollType::Tab, 1)),
+            "previous" | "prev" => Some(Self::Previous(ScrollType::Tab, 1)),
+            "readability" => Some(Self::HumanReadable),
+            "docs" | "help" => Some(Self::OpenRepo),
+            "trace" => Some(Self::TraceCalls),
+            _ => None,
+        }
+    }
 }
 
 impl From<KeyEvent> for Command {
@@ -89,6 +110,7 @@ impl From<KeyEvent> for Command {
                 }
             }
             KeyCode::Char('/') => Self::Input(InputCommand::Enter),
+            KeyCode::Char(':') => Self::CommandPrompt(CommandPromptCommand::Enter),
             KeyCode::Char('f') => {
                 if key_event.modifiers == KeyModifiers::CONTROL {
                     Self::Input(InputCommand::Enter)
@@ -132,6 +154,34 @@ pub enum InputCommand {
 }
 
 impl InputCommand {
+    /// Parses the event.
+    pub fn parse(key_event: KeyEvent, input: &Input) -> Self {
+        if key_event.code == KeyCode::Esc
+            || (key_event.code == KeyCode::Backspace && input.value().is_empty())
+        {
+            Self::Exit
+        } else if key_event.code == KeyCode::Enter {
+            Self::Confirm
+        } else {
+            Self::Handle(Event::Key(key_event))
+        }
+    }
+}
+
+/// Command prompt (`:`) mode command.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CommandPromptCommand {
+    /// Handle a key event while typing a command.
+    Handle(Event),
+    /// Enter command prompt mode.
+    Enter,
+    /// Run the typed command.
+    Confirm,
+    /// Exit command prompt mode.
+    Exit,
+}
+
+impl CommandPromptCommand {
     /// Parses the event.
     pub fn parse(key_event: KeyEvent, input: &Input) -> Self {
         if key_event.code == KeyCode::Esc
@@ -190,5 +240,73 @@ impl HexdumpCommand {
             ),
             _ => Self::Handle(Event::Key(key_event)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enter_command_prompt() {
+        assert_eq!(
+            Command::from(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)),
+            Command::CommandPrompt(CommandPromptCommand::Enter)
+        );
+    }
+
+    #[test]
+    fn test_parse_command_prompt_command() {
+        let input = Input::default().with_value(String::from("quit"));
+        assert_eq!(
+            CommandPromptCommand::parse(
+                KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE),
+                &input
+            ),
+            CommandPromptCommand::Handle(Event::Key(KeyEvent::new(
+                KeyCode::Char('t'),
+                KeyModifiers::NONE
+            )))
+        );
+        assert_eq!(
+            CommandPromptCommand::parse(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &input),
+            CommandPromptCommand::Confirm
+        );
+        assert_eq!(
+            CommandPromptCommand::parse(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &input),
+            CommandPromptCommand::Exit
+        );
+        assert_eq!(
+            CommandPromptCommand::parse(
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+                &Input::default()
+            ),
+            CommandPromptCommand::Exit
+        );
+    }
+
+    #[test]
+    fn test_parse_prompt() {
+        assert_eq!(Command::parse_prompt("quit"), Some(Command::Exit));
+        assert_eq!(Command::parse_prompt("q"), Some(Command::Exit));
+        assert_eq!(Command::parse_prompt("  exit  "), Some(Command::Exit));
+        assert_eq!(Command::parse_prompt("top"), Some(Command::Top));
+        assert_eq!(Command::parse_prompt("bottom"), Some(Command::Bottom));
+        assert_eq!(
+            Command::parse_prompt("next"),
+            Some(Command::Next(ScrollType::Tab, 1))
+        );
+        assert_eq!(
+            Command::parse_prompt("prev"),
+            Some(Command::Previous(ScrollType::Tab, 1))
+        );
+        assert_eq!(
+            Command::parse_prompt("readability"),
+            Some(Command::HumanReadable)
+        );
+        assert_eq!(Command::parse_prompt("docs"), Some(Command::OpenRepo));
+        assert_eq!(Command::parse_prompt("trace"), Some(Command::TraceCalls));
+        assert_eq!(Command::parse_prompt("bogus"), None);
+        assert_eq!(Command::parse_prompt(""), None);
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -37,6 +37,12 @@ pub struct State<'a> {
     pub input: Input,
     /// Enable input.
     pub input_mode: bool,
+    /// Command prompt input.
+    pub command_input: Input,
+    /// Enable command prompt.
+    pub command_mode: bool,
+    /// Message shown when a typed command is not recognized.
+    pub command_error: Option<String>,
     /// Strings call completed.
     pub strings_loaded: bool,
     /// System calls completed.
@@ -69,6 +75,9 @@ impl<'a> State<'a> {
             show_details: false,
             input: Input::default(),
             input_mode: false,
+            command_input: Input::default(),
+            command_mode: false,
+            command_error: None,
             strings_loaded: false,
             system_calls_loaded: false,
             dynamic_scroll_index: 0,
@@ -124,6 +133,35 @@ impl<'a> State<'a> {
                 }
                 self.handle_tab()?;
             }
+            Command::CommandPrompt(command) => match command {
+                CommandPromptCommand::Enter => {
+                    self.command_mode = true;
+                    self.command_error = None;
+                }
+                CommandPromptCommand::Handle(event) => {
+                    self.command_input.handle_event(&event);
+                }
+                CommandPromptCommand::Confirm => {
+                    let value = self.command_input.value().to_string();
+                    self.command_input = Input::default();
+                    self.command_mode = false;
+                    match Command::parse_prompt(&value) {
+                        Some(command) => {
+                            self.command_error = None;
+                            return self.run_command(command, event_sender);
+                        }
+                        None => {
+                            if !value.trim().is_empty() {
+                                self.command_error = Some(format!("unknown command: {value}"));
+                            }
+                        }
+                    }
+                }
+                CommandPromptCommand::Exit => {
+                    self.command_input = Input::default();
+                    self.command_mode = false;
+                }
+            },
             Command::Hexdump(command) => match command {
                 HexdumpCommand::Handle(event) => {
                     self.analyzer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -926,13 +926,16 @@ pub fn render_strings(state: &mut State, frame: &mut Frame, rect: Rect) {
 
 /// Renders the cursor.
 fn render_cursor(state: &mut State<'_>, area: Rect, frame: &mut Frame<'_>) {
-    if state.input_mode {
+    let cursor_value = if state.input_mode {
+        Some(format!("search: {}", state.input.value()))
+    } else if state.command_mode {
+        Some(format!(":{}", state.command_input.value()))
+    } else {
+        None
+    };
+    if let Some(value) = cursor_value {
         let (x, y) = (
-            area.x
-                + Input::default()
-                    .with_value(format!("search: {}", state.input.value()))
-                    .visual_cursor() as u16
-                + 2,
+            area.x + Input::default().with_value(value).visual_cursor() as u16 + 2,
             area.bottom().saturating_sub(1),
         );
         frame.render_widget(
@@ -1121,12 +1124,26 @@ pub fn render_dynamic_analysis(state: &mut State, frame: &mut Frame, rect: Rect)
 
 /// Returns the input line.
 fn get_input_line<'a>(state: &'a State) -> Line<'a> {
-    if !state.input.value().is_empty() || state.input_mode {
+    if state.command_mode {
+        Line::from(vec![
+            "|".fg(Color::Rgb(100, 100, 100)),
+            ":".yellow(),
+            state.command_input.value().fg(state.accent_color),
+            " ".into(),
+            "|".fg(Color::Rgb(100, 100, 100)),
+        ])
+    } else if !state.input.value().is_empty() || state.input_mode {
         Line::from(vec![
             "|".fg(Color::Rgb(100, 100, 100)),
             "search: ".yellow(),
             state.input.value().fg(state.accent_color),
             if state.input_mode { " " } else { "" }.into(),
+            "|".fg(Color::Rgb(100, 100, 100)),
+        ])
+    } else if let Some(error) = &state.command_error {
+        Line::from(vec![
+            "|".fg(Color::Rgb(100, 100, 100)),
+            error.as_str().fg(Color::Red),
             "|".fg(Color::Rgb(100, 100, 100)),
         ])
     } else {

--- a/website/src/content/docs/usage/static-analysis.md
+++ b/website/src/content/docs/usage/static-analysis.md
@@ -62,3 +62,16 @@ This table shows the common sections found in the binary file, similar to the ou
 You can press <kbd>h</kbd> and <kbd>l</kbd> to scroll horizontally and <kbd>/</kbd> to search for a specific value.
 
 ![static table](../../assets/static-table.gif)
+
+You can also press <kbd>:</kbd> to open the command prompt and run a command by name, then press <kbd>enter</kbd> to run it or <kbd>esc</kbd> to cancel. The following commands are available:
+
+| Command                    | Action                    |
+| -------------------------- | ------------------------- |
+| `quit` (`q`, `exit`)       | Quit the application.     |
+| `top`                      | Go to the top.            |
+| `bottom`                   | Go to the bottom.         |
+| `next`                     | Switch to the next tab.   |
+| `previous` (`prev`)        | Switch to the previous tab.|
+| `readability`              | Toggle human readable format.|
+| `trace`                    | Trace system calls.       |
+| `docs` (`help`)            | Open the documentation.   |


### PR DESCRIPTION
## Description of change

Adds a Vim-like command prompt as requested. Press `:` to open a prompt at the bottom, type a command by name and press `enter` to run it (or `esc` to cancel). If the name isn't recognized, a short error is shown instead of doing anything.

The prompt reuses the existing input handling (the same mechanism as `/` search) and maps the typed name onto the existing commands, so it doesn't add any behavior of its own. Supported for now:

- `quit` (`q`, `exit`)
- `top`, `bottom`
- `next`, `previous` (`prev`)
- `readability`
- `trace`
- `docs` (`help`)

It's easy to add more names later since it all goes through `Command::parse_prompt`.

Closes #64

## How has this been tested? (if applicable)

Added unit tests for the `:` key binding, the prompt key parsing and the command name lookup. Also ran `cargo test`, `cargo fmt --all -- --check` and `cargo clippy` locally.
