### PR TITLE
feat(tui): support searching for shared libraries

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -383,6 +383,13 @@ impl<'a> State<'a> {
                         .clone()
                         .into_iter()
                         .map(|(name, lib)| vec![name, lib])
+                        .filter(|items| {
+                            self.input.value().is_empty()
+                                || items.iter().any(|item| {
+                                    item.to_lowercase()
+                                        .contains(&self.input.value().to_lowercase())
+                                })
+                        })
                         .collect(),
                 );
             }
@@ -455,6 +462,7 @@ impl<'a> State<'a> {
                 vec![
                     ("o", "Open docs"),
                     ("⏎ ", "Analyze lib"),
+                    ("/", "Search"),
                     ("h/j/k/l", "Scroll"),
                     ("Tab", "Next"),
                     ("⇧+Tab", "Previous"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -395,7 +395,7 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
     });
     let area = Layout::new(
         Direction::Vertical,
-        if state.list.items.is_empty() {
+        if state.analyzer.dependencies.is_empty() {
             vec![Constraint::Max(lines.len() as u16 + 2)]
         } else if (lines.len() as u16).saturating_sub(2) < rect.height / 2 {
             vec![
@@ -458,7 +458,7 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
         &mut ScrollbarState::new(max_height).position(state.general_scroll_index),
     );
 
-    if state.list.items.is_empty() {
+    if state.analyzer.dependencies.is_empty() {
         return;
     }
 
@@ -537,7 +537,8 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
                         Line::default()
                     }
                     .right_aligned(),
-                ),
+                )
+                .title_bottom(get_input_line(state)),
         )
         .row_highlight_style(Style::default().fg(Color::Green)),
         table_area,
@@ -554,6 +555,7 @@ pub fn render_general_info(state: &mut State, frame: &mut Frame, rect: Rect) {
         &mut ScrollbarState::new(items.len())
             .position(state.list.state.selected().unwrap_or_default()),
     );
+    render_cursor(state, table_area, frame);
 }
 
 /// Renders the static analysis tab.
@@ -1120,12 +1122,12 @@ pub fn render_dynamic_analysis(state: &mut State, frame: &mut Frame, rect: Rect)
 }
 
 /// Returns the input line.
-fn get_input_line<'a>(state: &'a State) -> Line<'a> {
+fn get_input_line(state: &State) -> Line<'static> {
     if !state.input.value().is_empty() || state.input_mode {
         Line::from(vec![
             "|".fg(Color::Rgb(100, 100, 100)),
             "search: ".yellow(),
-            state.input.value().fg(state.accent_color),
+            state.input.value().to_string().fg(state.accent_color),
             if state.input_mode { " " } else { "" }.into(),
             "|".fg(Color::Rgb(100, 100, 100)),
         ])

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,4 +1,9 @@
-use binsider::{app::Analyzer, error::Result, file::FileInfo, prelude::Event};
+use binsider::{
+    app::Analyzer,
+    error::Result,
+    file::FileInfo,
+    prelude::{Event, State},
+};
 use std::{fs, path::PathBuf, sync::mpsc};
 
 fn get_test_path() -> PathBuf {
@@ -44,5 +49,58 @@ fn test_extract_strings() -> Result<()> {
     } else {
         panic!("strings did not succeed");
     }
+    Ok(())
+}
+
+#[test]
+fn test_general_tab_search() -> Result<()> {
+    let test_bytes = get_test_bytes()?;
+    let test_path = get_test_path();
+    let analyzer = Analyzer::new(
+        FileInfo::new(
+            test_path.to_str().expect("failed to get test path"),
+            None,
+            test_bytes.as_slice(),
+        )?,
+        4,
+        vec![],
+    )?;
+    let mut state = State::new(analyzer, None)?;
+    // Use a fixed set of dependencies so the test does not depend on the
+    // linker resolving the real ones at runtime.
+    state.analyzer.dependencies = vec![
+        ("libc.so.6".to_string(), "/lib/libc.so.6".to_string()),
+        (
+            "libgcc_s.so.1".to_string(),
+            "/lib/libgcc_s.so.1".to_string(),
+        ),
+        (
+            "libssl.so.3".to_string(),
+            "/usr/lib/libssl.so.3".to_string(),
+        ),
+    ];
+
+    // Empty query keeps every dependency.
+    state.input = "".into();
+    state.handle_tab()?;
+    assert_eq!(state.list.items.len(), 3);
+
+    // Match against the library name.
+    state.input = "ssl".into();
+    state.handle_tab()?;
+    assert_eq!(state.list.items.len(), 1);
+    assert_eq!(state.list.items[0][0], "libssl.so.3");
+
+    // Match against the resolved path, case-insensitively.
+    state.input = "USR".into();
+    state.handle_tab()?;
+    assert_eq!(state.list.items.len(), 1);
+    assert_eq!(state.list.items[0][0], "libssl.so.3");
+
+    // A query that matches nothing clears the list.
+    state.input = "nope".into();
+    state.handle_tab()?;
+    assert!(state.list.items.is_empty());
+
     Ok(())
 }


### PR DESCRIPTION
<!--- Thank you for contributing to binsider! -->

## Description of change

Closes #45.

The General tab already lists the shared library dependencies, but the `/` search only did anything on the other tabs. This wires the same filter into the dependencies list so you can type to narrow it down by library name or resolved path (case insensitive), and adds the search hint to the key bindings. The search box now stays visible whenever the binary has dependencies, even when the current query happens to match none of them.

## How has this been tested? (if applicable)

Added a test in `tests/app.rs` that drives `handle_tab` with a few queries and checks the filtered list. `cargo test --all-features --workspace` passes locally.