### PR TITLE
fix(tui): preserve list selection when toggling readability

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -364,7 +364,9 @@ impl<'a> State<'a> {
                 if self.tab == Tab::StaticAnalysis {
                     self.analyzer.elf.program_headers.toggle_readability();
                     self.analyzer.elf.section_headers.toggle_readability();
+                    let selected = self.list.state.selected();
                     self.handle_tab()?;
+                    self.list.reselect(selected);
                 }
             }
             Command::Nothing => {}

--- a/src/tui/widgets/list.rs
+++ b/src/tui/widgets/list.rs
@@ -71,6 +71,19 @@ impl<T> SelectableList<T> {
         };
         self.state.select(Some(i));
     }
+
+    /// Restores a previously selected index, clamping it to the current items.
+    ///
+    /// Useful after replacing `items` (e.g. via `with_items`) with data that
+    /// did not actually reorder or resize the list, where resetting the
+    /// selection back to the top would otherwise be surprising.
+    pub fn reselect(&mut self, index: Option<usize>) {
+        if let Some(index) = index {
+            if !self.items.is_empty() {
+                self.state.select(Some(index.min(self.items.len() - 1)));
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -93,5 +106,30 @@ mod tests {
         list.state.select(None);
         list.previous(1);
         assert_eq!(Some(0), list.state.selected());
+    }
+
+    #[test]
+    fn test_reselect() {
+        let mut list = SelectableList::with_items(vec!["data1", "data2", "data3"]);
+        list.state.select(Some(1));
+        let previous = list.state.selected();
+
+        // Rebuilding via `with_items` resets the selection to the top.
+        list = SelectableList::with_items(vec!["data1", "data2", "data3"]);
+        assert_eq!(Some(0), list.state.selected());
+
+        // `reselect` restores the previously selected index.
+        list.reselect(previous);
+        assert_eq!(Some(1), list.state.selected());
+
+        // An out-of-range index is clamped to the last item.
+        list.reselect(Some(10));
+        assert_eq!(Some(2), list.state.selected());
+
+        // Reselecting on an empty list is a no-op.
+        let mut empty = SelectableList::<&str>::with_items(vec![]);
+        empty.state.select(None);
+        empty.reselect(Some(1));
+        assert_eq!(None, empty.state.selected());
     }
 }


### PR DESCRIPTION
## Summary
Toggling "Human Readable" (`s`) on the static analysis tab called `handle_tab()`, which always rebuilds `self.list` via `SelectableList::with_items` -> `SelectableList::new`, and `new` unconditionally resets the selection to index 0. Since the toggle only reformats existing rows in place rather than reordering or resizing them, the highlighted row visibly jumped back to the top even though nothing moved — matching the repro in #150.

## Fix
Added `SelectableList::reselect(&mut self, index: Option<usize>)`, which restores a previously selected index after a rebuild, clamping it to the current item count as a safety net (in case a rebuild ever does change row count, e.g. together with an active search filter) and no-oping on an empty list. Used it in the `Command::HumanReadable` handler in `state.rs`: capture `self.list.state.selected()` before `handle_tab()`, then call `self.list.reselect(selected)` after.

## Testing
- Added `test_reselect` in `src/tui/widgets/list.rs`, covering: restoring a valid index after a rebuild resets it to 0, clamping an out-of-range index to the last item, and no-op on an empty list.
- `cargo test --no-default-features --lib` passes (6 tests, 1 ignored pre-existing).
- `cargo clippy --no-default-features --lib -- -D warnings` shows no new warnings from the changed files (one pre-existing, unrelated hit at `state.rs:350` predates this change).
- `cargo fmt --check` passes.
- Note: this environment (macOS) can't build/run the two `tests/app.rs` integration tests, since the locally-compiled test binary is Mach-O, not ELF (`ElfError(BadMagic(...))`) — that's a pre-existing platform gap in this sandbox, unrelated to this change, and those tests are untouched here.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)