### PR TITLE
feat(cli): expose dynamic analysis formatting options

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -36,6 +36,40 @@ pub struct Args {
     /// Accent color of the application.
     #[arg(env, long, value_name = "COLOR")]
     pub accent_color: Option<Color>,
+
+    /// Dynamic analysis options.
+    #[cfg(feature = "dynamic-analysis")]
+    #[command(flatten)]
+    pub trace: TraceArgs,
+}
+
+/// Options for formatting dynamic analysis output.
+#[cfg(feature = "dynamic-analysis")]
+#[derive(Clone, Debug, Default, clap::Args)]
+pub struct TraceArgs {
+    /// Display system call numbers during dynamic analysis.
+    #[arg(long)]
+    pub syscall_number: bool,
+
+    /// Print un-abbreviated strings during dynamic analysis.
+    #[arg(long)]
+    pub no_abbrev: bool,
+
+    /// Maximum string argument size to print during dynamic analysis.
+    #[arg(long, conflicts_with = "no_abbrev")]
+    pub string_limit: Option<usize>,
+}
+
+#[cfg(feature = "dynamic-analysis")]
+impl From<TraceArgs> for lurk_cli::args::Args {
+    fn from(args: TraceArgs) -> Self {
+        Self {
+            syscall_number: args.syscall_number,
+            no_abbrev: args.no_abbrev,
+            string_limit: args.string_limit,
+            ..Self::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -45,5 +79,48 @@ mod tests {
     #[test]
     fn test_args() {
         Args::command().debug_assert();
+    }
+
+    #[cfg(feature = "dynamic-analysis")]
+    #[test]
+    fn test_trace_options() {
+        let args = Args::try_parse_from([
+            "binsider",
+            "--syscall-number",
+            "--string-limit",
+            "128",
+            "-n",
+            "8",
+            "/bin/ls",
+        ])
+        .expect("trace options should parse");
+        assert_eq!(args.min_strings_len, 8);
+        assert_eq!(args.files, vec![PathBuf::from("/bin/ls")]);
+        let trace: lurk_cli::args::Args = args.trace.into();
+        assert!(trace.syscall_number);
+        assert_eq!(trace.string_limit, Some(128));
+        assert!(!trace.no_abbrev);
+
+        let args =
+            Args::try_parse_from(["binsider", "--no-abbrev"]).expect("trace options should parse");
+        let trace: lurk_cli::args::Args = args.trace.into();
+        assert!(trace.no_abbrev);
+        assert_eq!(trace.string_limit, None);
+    }
+
+    #[cfg(feature = "dynamic-analysis")]
+    #[test]
+    fn test_trace_option_validation() {
+        let error = Args::try_parse_from(["binsider", "--no-abbrev", "--string-limit", "128"])
+            .expect_err("abbreviation options must conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(Args::try_parse_from(["binsider", "--string-limit", "invalid"]).is_err());
+        let trace: lurk_cli::args::Args = Args::try_parse_from(["binsider"])
+            .expect("default options should parse")
+            .trace
+            .into();
+        assert!(!trace.syscall_number);
+        assert!(!trace.no_abbrev);
+        assert_eq!(trace.string_limit, None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,11 @@ pub fn start_tui(analyzer: Analyzer, args: Args) -> Result<()> {
             Event::Trace => {
                 state.system_calls_loaded = false;
                 tui.toggle_pause()?;
-                tracer::trace_syscalls(&state.analyzer.file, tui.events.sender.clone());
+                tracer::trace_syscalls(
+                    &state.analyzer.file,
+                    args.trace.clone().into(),
+                    tui.events.sender.clone(),
+                );
             }
             #[cfg(feature = "dynamic-analysis")]
             Event::TraceResult(syscalls) => {

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -16,7 +16,7 @@ use crate::TraceData;
 use nix::unistd::{fork, ForkResult};
 
 /// Trace system calls and signals.
-pub fn trace_syscalls(file: &FileInfo, event_sender: mpsc::Sender<Event>) {
+pub fn trace_syscalls(file: &FileInfo, args: Args, event_sender: mpsc::Sender<Event>) {
     let event_sender = event_sender.clone();
     let mut command = vec![file.path.to_string()];
     if let Some(args) = &file.arguments {
@@ -35,7 +35,7 @@ pub fn trace_syscalls(file: &FileInfo, event_sender: mpsc::Sender<Event>) {
             let mut syscalls = Vec::new();
             let mut tracer = Tracer::new(
                 pid,
-                Args::default(),
+                args,
                 Box::new(Cursor::new(&mut syscalls)),
                 StyleConfig {
                     pid: Style::new().cyan(),

--- a/website/src/content/docs/usage/dynamic-analysis.md
+++ b/website/src/content/docs/usage/dynamic-analysis.md
@@ -44,6 +44,20 @@ You can use the following keys to interact with the dynamic analysis:
 | <kbd>r</kbd>                | Re-run executable    |
 | <kbd>enter</kbd>            | Show details         |
 
+### Trace options
+
+You can configure the trace output when starting `binsider`:
+
+```sh
+binsider --syscall-number --string-limit 128 /bin/ls
+```
+
+- `--syscall-number` displays system call numbers.
+- `--string-limit <SIZE>` limits the number of bytes shown for string arguments.
+- `--no-abbrev` prints strings without abbreviation. It cannot be combined with `--string-limit`.
+
+These options apply each time you run dynamic analysis and are available only in builds with the `dynamic-analysis` feature.
+
 ### Details
 
 When you press <kbd>enter</kbd>, you will get a summary output of the execution:


### PR DESCRIPTION
## Description of change

Adds `--syscall-number`, `--no-abbrev`, and `--string-limit` CLI options and forwards them to lurk whenever dynamic analysis starts. The two abbreviation options conflict, and the new options are compiled only with the `dynamic-analysis` feature. Includes usage documentation.

Refs #7. This covers trace formatting; attaching to an existing process remains outside this change.

## How has this been tested (if applicable)

- `cargo test --all-features --workspace`: 9 passed, 1 existing ignored test.
- `cargo test --no-default-features --workspace`: 7 passed, 1 existing ignored test.
- `cargo clippy --all-targets --all-features --workspace`: passes with existing warnings in `tui/state.rs` and `tui/ui.rs`.
- `cargo fmt --all -- --check`.
- Added tests for option forwarding, defaults, invalid values, conflicts, and compatibility with `-n` (minimum strings length).

Prepared with OpenAI Codex assistance.
